### PR TITLE
Change container registry in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,5 +37,5 @@ jobs:
                 oci-archive:"${rock_file}" \
                 docker-daemon:"ghcr.io/openstack-charmers/${image_name}:${version}"
               echo "Publishing rock ${image_name}:${version}"
-              docker push ghcr.io/openstack-charmers/${image_name}:${version}
+              docker push ghcr.io/openstack-snaps/${image_name}:${version}
           done


### PR DESCRIPTION
Change container registry to ghcr.io/openstack-snaps in publish workflow.