### PR TITLE
Use service user & group when appropriate

### DIFF
--- a/rocks/cinder-scheduler/rockcraft.yaml
+++ b/rocks/cinder-scheduler/rockcraft.yaml
@@ -9,7 +9,7 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
+# Disabled until rockcraft supports
 # overlay packages from repositories
 # package-repositories:
 #   - type: apt
@@ -19,6 +19,8 @@ platforms:
 services:
   cinder-scheduler:
     override: replace
+    user: cinder
+    group: cinder
     command: cinder-scheduler --use-syslog
 
 parts:

--- a/rocks/cinder-volume/rockcraft.yaml
+++ b/rocks/cinder-volume/rockcraft.yaml
@@ -9,7 +9,7 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
+# Disabled until rockcraft supports
 # overlay packages from repositories
 # package-repositories:
 #   - type: apt
@@ -19,6 +19,8 @@ platforms:
 services:
   cinder-volume:
     override: replace
+    user: cinder
+    group: cinder
     command: cinder-volume --use-syslog
 
 parts:

--- a/rocks/glance-api/rockcraft.yaml
+++ b/rocks/glance-api/rockcraft.yaml
@@ -9,7 +9,7 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
+# Disabled until rockcraft supports
 # overlay packages from repos
 # package-repositories:
 #   - type: apt
@@ -19,7 +19,9 @@ platforms:
 services:
   glance-api:
     override: replace
-    command: /usr/bin/glance-api --config-file /etc/glance/glance-api.conf
+    user: glance
+    group: glance
+    command: /usr/bin/glance-api --config-file /etc/glance/glance-api.conf --use-syslog
   "apache forwarder":
     override: replace
     command: /usr/sbin/apache2ctl -DFOREGROUND

--- a/rocks/neutron-server/rockcraft.yaml
+++ b/rocks/neutron-server/rockcraft.yaml
@@ -9,7 +9,7 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
+# Disabled until rockcraft supports
 # overlay packages from repositories
 # package-repositories:
 #   - type: apt
@@ -19,7 +19,9 @@ platforms:
 services:
   neutron-server:
     override: replace
-    command: neutron-server
+    user: neutron
+    group: neutron
+    command: neutron-server --use-syslog
 
 parts:
   neutron-user:

--- a/rocks/nova-conductor/rockcraft.yaml
+++ b/rocks/nova-conductor/rockcraft.yaml
@@ -9,7 +9,7 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
+# Disabled until rockcraft supports
 # overlay packages from repositories
 # package-repositories:
 #   - type: apt
@@ -19,7 +19,9 @@ platforms:
 services:
   nova-conductor:
     override: replace
-    command: nova-conductor
+    user: nova
+    group: nova
+    command: nova-conductor --use-syslog
 
 parts:
   nova-user:

--- a/rocks/nova-scheduler/rockcraft.yaml
+++ b/rocks/nova-scheduler/rockcraft.yaml
@@ -9,7 +9,7 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
+# Disabled until rockcraft supports
 # overlay packages from repositories
 # package-repositories:
 #   - type: apt
@@ -19,7 +19,9 @@ platforms:
 services:
   nova-scheduler:
     override: replace
-    command: nova-scheduler
+    user: nova
+    group: nova
+    command: nova-scheduler --use-syslog
 
 parts:
   nova-user:


### PR DESCRIPTION
For standalone OpenStack services use the created user and group by default for execution of the pebble services.

For apache2 based WSGI services this is not required; Apache deals with dropping priviledges based on WSGI service definitions.