### PR TITLE
Update horizon home path

### DIFF
--- a/rocks/horizon/rockcraft.yaml
+++ b/rocks/horizon/rockcraft.yaml
@@ -31,7 +31,7 @@ parts:
         --gid 42420 \
         --uid 42420 \
         --no-create-home \
-        --home /var/lib/horizon \
+        --home /var/lib/openstack-dashboard \
         --root $CRAFT_OVERLAY \
         --system \
         --shell /bin/false \


### PR DESCRIPTION
Hom path specified a directory that does not exist. Use the one created by the `openstack-dashboard` package.