### PR TITLE
Use overlay-packages instead of overlay-script

### DIFF
--- a/cookiecutter_code/rock-init.py
+++ b/cookiecutter_code/rock-init.py
@@ -1,40 +1,35 @@
 #!/usr/bin/env python3
 
-import shutil
-import yaml
 import argparse
-import tempfile
 import os
-import glob
+import sys
 from cookiecutter.main import cookiecutter
-import subprocess
 from pathlib import Path
 
-from datetime import datetime
-import sys
 
 def get_suggested_packages(container_name):
     container_packages = {
-        'cinder-api': "cinder-api  apache2 libapache2-mod-wsgi-py3 openssl",
-        'cinder-scheduler': "cinder-scheduler",
-        'cinder-volume': "lsscsi multipath-tools nfs-common nvme-cli sysfsutils targetcli-fb thin-provisioning-tools tgt cinder-volume python3-rtslib-fb",
-        'glance-api': "nfs-common qemu-utils  glance python3-boto3 python3-os-brick python3-oslo.vmware python3-rados python3-rbd apache2 libapache2-mod-wsgi-py3 openssl",
-        'openstack-dashboard': "openstack-dashboard apache2 libapache2-mod-wsgi-py3 openssl",
-        'keystone': "libapache2-mod-auth-gssapi python3-requests-kerberos keystone libapache2-mod-auth-mellon libapache2-mod-auth-openidc python3-ldappool",
-        'neutron-server': "python3-ironic-neutron-agent python3-neutron-dynamic-routing python3-neutron-vpnaas iproute2 iputils-ping keepalived net-tools radvd neutron-plugin-ml2 neutron-server openvswitch-switch python3-networking-sfc python3-openvswitch python3-oslo.vmware",
-        'nova-api': "nova-api python3-memcache nova-common openvswitch-switch python3-nova ovmf apache2 libapache2-mod-wsgi-py3 openssl patch",
-        'nova-conductor': "nova-conductor nova-common openvswitch-switch python3-nova ovmf",
-        'nova-scheduler': "nova-schedule nova-common openvswitch-switch python3-nova ovmf",
-        'ovn-sb-db-server': "ovn-central ovn-common openvswitch-switch python3-openvswitch python3-netifaces tcpdump",
-        'ovn-nb-db-server': "ovn-central ovn-common openvswitch-switch python3-openvswitch python3-netifaces tcpdump",
-        'ovn-northd': "ovn-central ovn-common openvswitch-switch python3-openvswitch python3-netifaces tcpdump",
-        'placement-api': "placement-api placement-common python3-memcache apache2 libapache2-mod-wsgi-py3 openssl"
+        "cinder-api": "cinder-api apache2 libapache2-mod-wsgi-py3 openssl",
+        "cinder-scheduler": "cinder-scheduler",
+        "cinder-volume": "lsscsi multipath-tools nfs-common nvme-cli sysfsutils targetcli-fb thin-provisioning-tools tgt cinder-volume python3-rtslib-fb",
+        "glance-api": "nfs-common qemu-utils  glance python3-boto3 python3-os-brick python3-oslo.vmware python3-rados python3-rbd apache2 libapache2-mod-wsgi-py3 openssl",
+        "openstack-dashboard": "openstack-dashboard apache2 libapache2-mod-wsgi-py3 openssl",
+        "keystone": "libapache2-mod-auth-gssapi python3-requests-kerberos keystone libapache2-mod-auth-mellon libapache2-mod-auth-openidc python3-ldappool",
+        "neutron-server": "python3-ironic-neutron-agent python3-neutron-dynamic-routing python3-neutron-vpnaas iproute2 iputils-ping keepalived net-tools radvd neutron-plugin-ml2 neutron-server openvswitch-switch python3-networking-sfc python3-openvswitch python3-oslo.vmware",
+        "nova-api": "nova-api python3-memcache nova-common openvswitch-switch python3-nova ovmf apache2 libapache2-mod-wsgi-py3 openssl patch",
+        "nova-conductor": "nova-conductor nova-common openvswitch-switch python3-nova ovmf",
+        "nova-scheduler": "nova-schedule nova-common openvswitch-switch python3-nova ovmf",
+        "ovn-sb-db-server": "ovn-central ovn-common openvswitch-switch python3-openvswitch python3-netifaces tcpdump",
+        "ovn-nb-db-server": "ovn-central ovn-common openvswitch-switch python3-openvswitch python3-netifaces tcpdump",
+        "ovn-northd": "ovn-central ovn-common openvswitch-switch python3-openvswitch python3-netifaces tcpdump",
+        "placement-api": "placement-api placement-common python3-memcache apache2 libapache2-mod-wsgi-py3 openssl",
     }
-    return container_packages.get(container_name)
+    return container_packages.get(container_name, "")
+
 
 def arg_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument('rock_name', help='Name of rock')
+    parser.add_argument("rock_name", help="Name of rock")
     return parser.parse_args()
 
 
@@ -42,12 +37,17 @@ def main() -> int:
     """Echo the input arguments to standard output"""
     args = arg_parser()
     cookie_dir = Path(__file__).resolve().parent
-    output_dir = cookie_dir  / "../rocks/"
+    output_dir = cookie_dir / "../rocks/"
     output_dir.mkdir(parents=True, exist_ok=True)
     os.chdir(cookie_dir)
     packages = "sudo " + get_suggested_packages(args.rock_name)
-    cookiecutter('rock', output_dir=output_dir, extra_context={'rock_name': args.rock_name, "packages": packages})
+    cookiecutter(
+        "rock",
+        output_dir=str(output_dir),
+        extra_context={"rock_name": args.rock_name, "packages": packages},
+    )
     return 0
 
-if __name__ == '__main__':
-    sys.exit(main()) 
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cookiecutter_code/rock/{{cookiecutter.rock_name}}/rockcraft.yaml
+++ b/cookiecutter_code/rock/{{cookiecutter.rock_name}}/rockcraft.yaml
@@ -9,12 +9,10 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
-# overlay packages from repositories
-# package-repositories:
-#   - type: apt
-#     cloud: antelope
-#     priority: always
+package-repositories:
+  - type: apt
+    cloud: antelope
+    priority: always
 
 services:
   wsgi-{{ cookiecutter.rock_name }}:
@@ -24,17 +22,4 @@ services:
 parts:
   {{ cookiecutter.rock_name }}:
     plugin: nil
-    overlay-packages:
-      - software-properties-common
-    overlay-script: |
-      mount /etc/resolv.conf $CRAFT_OVERLAY/etc/resolv.conf --bind
-      mount proc $CRAFT_OVERLAY/proc -t proc
-      mount sysfs $CRAFT_OVERLAY/sys -t sysfs
-      mount /dev $CRAFT_OVERLAY/dev --rbind --make-private
-      chroot $CRAFT_OVERLAY add-apt-repository cloud-archive:antelope
-      chroot $CRAFT_OVERLAY apt update
-      chroot $CRAFT_OVERLAY bash -c "DEBIAN_FRONTEND=noninteractive apt install {{ cookiecutter.packages }} --yes"
-      umount --recursive $CRAFT_OVERLAY/dev
-      umount $CRAFT_OVERLAY/sys
-      umount $CRAFT_OVERLAY/proc
-      umount $CRAFT_OVERLAY/etc/resolv.conf
+    overlay-packages: {{ cookiecutter.packages.split() | tojson }}

--- a/rocks/cinder-api/rockcraft.yaml
+++ b/rocks/cinder-api/rockcraft.yaml
@@ -9,12 +9,10 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
-# overlay packages from repositories
-# package-repositories:
-#   - type: apt
-#     cloud: antelope
-#     priority: always
+package-repositories:
+  - type: apt
+    cloud: antelope
+    priority: always
 
 services:
   wsgi-cinder-api:
@@ -41,17 +39,8 @@ parts:
     after: [cinder-user]
     plugin: nil
     overlay-packages:
-      - software-properties-common
-    overlay-script: |
-      mount /etc/resolv.conf $CRAFT_OVERLAY/etc/resolv.conf --bind
-      mount proc $CRAFT_OVERLAY/proc -t proc
-      mount sysfs $CRAFT_OVERLAY/sys -t sysfs
-      mount /dev $CRAFT_OVERLAY/dev --rbind --make-private
-      chroot $CRAFT_OVERLAY add-apt-repository cloud-archive:antelope
-      chroot $CRAFT_OVERLAY apt update
-      chroot $CRAFT_OVERLAY bash -c "DEBIAN_FRONTEND=noninteractive apt install sudo cinder-api --yes"
-      chroot $CRAFT_OVERLAY bash -c echo > etc/apache2/ports.conf
-      umount --recursive $CRAFT_OVERLAY/dev
-      umount $CRAFT_OVERLAY/sys
-      umount $CRAFT_OVERLAY/proc
-      umount $CRAFT_OVERLAY/etc/resolv.conf
+      - sudo
+      - cinder-api
+    override-prime: |
+      craftctl default
+      echo > $CRAFT_PRIME/etc/apache2/ports.conf

--- a/rocks/cinder-scheduler/rockcraft.yaml
+++ b/rocks/cinder-scheduler/rockcraft.yaml
@@ -9,12 +9,10 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
-# overlay packages from repositories
-# package-repositories:
-#   - type: apt
-#     cloud: antelope
-#     priority: always
+package-repositories:
+  - type: apt
+    cloud: antelope
+    priority: always
 
 services:
   cinder-scheduler:
@@ -41,16 +39,5 @@ parts:
     after: [cinder-user]
     plugin: nil
     overlay-packages:
-      - software-properties-common
-    overlay-script: |
-      mount /etc/resolv.conf $CRAFT_OVERLAY/etc/resolv.conf --bind
-      mount proc $CRAFT_OVERLAY/proc -t proc
-      mount sysfs $CRAFT_OVERLAY/sys -t sysfs
-      mount /dev $CRAFT_OVERLAY/dev --rbind --make-private
-      chroot $CRAFT_OVERLAY add-apt-repository cloud-archive:antelope
-      chroot $CRAFT_OVERLAY apt update
-      chroot $CRAFT_OVERLAY bash -c "DEBIAN_FRONTEND=noninteractive apt install sudo cinder-scheduler --yes"
-      umount --recursive $CRAFT_OVERLAY/dev
-      umount $CRAFT_OVERLAY/sys
-      umount $CRAFT_OVERLAY/proc
-      umount $CRAFT_OVERLAY/etc/resolv.conf
+      - sudo
+      - cinder-scheduler

--- a/rocks/cinder-volume/rockcraft.yaml
+++ b/rocks/cinder-volume/rockcraft.yaml
@@ -9,12 +9,10 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
-# overlay packages from repositories
-# package-repositories:
-#   - type: apt
-#     cloud: antelope
-#     priority: always
+package-repositories:
+  - type: apt
+    cloud: antelope
+    priority: always
 
 services:
   cinder-volume:
@@ -41,16 +39,9 @@ parts:
     after: [cinder-user]
     plugin: nil
     overlay-packages:
-      - software-properties-common
-    overlay-script: |
-      mount /etc/resolv.conf $CRAFT_OVERLAY/etc/resolv.conf --bind
-      mount proc $CRAFT_OVERLAY/proc -t proc
-      mount sysfs $CRAFT_OVERLAY/sys -t sysfs
-      mount /dev $CRAFT_OVERLAY/dev --rbind --make-private
-      chroot $CRAFT_OVERLAY add-apt-repository cloud-archive:antelope
-      chroot $CRAFT_OVERLAY apt update
-      chroot $CRAFT_OVERLAY bash -c "DEBIAN_FRONTEND=noninteractive apt install sudo cinder-volume ceph-common nfs-common sysfsutils tgt --yes"
-      umount --recursive $CRAFT_OVERLAY/dev
-      umount $CRAFT_OVERLAY/sys
-      umount $CRAFT_OVERLAY/proc
-      umount $CRAFT_OVERLAY/etc/resolv.conf
+      - sudo
+      - cinder-volume
+      - ceph-common
+      - nfs-common
+      - sysfsutils
+      - tgt

--- a/rocks/glance-api/rockcraft.yaml
+++ b/rocks/glance-api/rockcraft.yaml
@@ -9,12 +9,10 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
-# overlay packages from repos
-# package-repositories:
-#   - type: apt
-#     cloud: antelope
-#     priority: always
+package-repositories:
+  - type: apt
+    cloud: antelope
+    priority: always
 
 services:
   glance-api:
@@ -44,17 +42,15 @@ parts:
     after: [glance-user]
     plugin: nil
     overlay-packages:
-      - software-properties-common
-    overlay-script: |
-      mount /etc/resolv.conf $CRAFT_OVERLAY/etc/resolv.conf --bind
-      mount proc $CRAFT_OVERLAY/proc -t proc
-      mount sysfs $CRAFT_OVERLAY/sys -t sysfs
-      mount /dev $CRAFT_OVERLAY/dev --rbind --make-private
-      chroot $CRAFT_OVERLAY add-apt-repository cloud-archive:antelope
-      chroot $CRAFT_OVERLAY apt update
-      chroot $CRAFT_OVERLAY bash -c "DEBIAN_FRONTEND=noninteractive apt install sudo ceph-common nfs-common glance python3-boto3 python3-rados python3-rbd apache2 libapache2-mod-wsgi-py3 --yes"
-      chroot $CRAFT_OVERLAY bash -c echo > etc/apache2/ports.conf
-      umount --recursive $CRAFT_OVERLAY/dev
-      umount $CRAFT_OVERLAY/sys
-      umount $CRAFT_OVERLAY/proc
-      umount $CRAFT_OVERLAY/etc/resolv.conf
+      - sudo
+      - ceph-common
+      - nfs-common
+      - glance
+      - python3-boto3
+      - python3-rados
+      - python3-rbd
+      - apache2
+      - libapache2-mod-wsgi-py3
+    override-prime: |
+      craftctl default
+      echo > $CRAFT_PRIME/etc/apache2/ports.conf

--- a/rocks/horizon/rockcraft.yaml
+++ b/rocks/horizon/rockcraft.yaml
@@ -9,12 +9,10 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
-# overlay packages from repositories
-# package-repositories:
-#   - type: apt
-#     cloud: antelope
-#     priority: always
+package-repositories:
+  - type: apt
+    cloud: antelope
+    priority: always
 
 services:
   wsgi-horizon:
@@ -41,17 +39,9 @@ parts:
     after: [horizon-user]
     plugin: nil
     overlay-packages:
-      - software-properties-common
-    overlay-script: |
-      mount /etc/resolv.conf $CRAFT_OVERLAY/etc/resolv.conf --bind
-      mount proc $CRAFT_OVERLAY/proc -t proc
-      mount sysfs $CRAFT_OVERLAY/sys -t sysfs
-      mount /dev $CRAFT_OVERLAY/dev --rbind --make-private
-      chroot $CRAFT_OVERLAY add-apt-repository cloud-archive:antelope
-      chroot $CRAFT_OVERLAY apt update
-      chroot $CRAFT_OVERLAY bash -c "DEBIAN_FRONTEND=noninteractive apt install sudo openstack-dashboard python3-mysqldb --yes"
-      chroot $CRAFT_OVERLAY bash -c echo > etc/apache2/ports.conf
-      umount --recursive $CRAFT_OVERLAY/dev
-      umount $CRAFT_OVERLAY/sys
-      umount $CRAFT_OVERLAY/proc
-      umount $CRAFT_OVERLAY/etc/resolv.conf
+      - sudo
+      - openstack-dashboard
+      - python3-mysqldb
+    override-prime: |
+      craftctl default
+      echo > $CRAFT_PRIME/etc/apache2/ports.conf

--- a/rocks/keystone/rockcraft.yaml
+++ b/rocks/keystone/rockcraft.yaml
@@ -9,12 +9,10 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
-# overlay packages from repositories
-# package-repositories:
-#   - type: apt
-#     cloud: antelope
-#     priority: always
+package-repositories:
+  - type: apt
+    cloud: antelope
+    priority: always
 
 services:
   wsgi-keystone:
@@ -41,17 +39,13 @@ parts:
     after: [keystone-user]
     plugin: nil
     overlay-packages:
-      - software-properties-common
-    overlay-script: |
-      mount /etc/resolv.conf $CRAFT_OVERLAY/etc/resolv.conf --bind
-      mount proc $CRAFT_OVERLAY/proc -t proc
-      mount sysfs $CRAFT_OVERLAY/sys -t sysfs
-      mount /dev $CRAFT_OVERLAY/dev --rbind --make-private
-      chroot $CRAFT_OVERLAY add-apt-repository cloud-archive:antelope
-      chroot $CRAFT_OVERLAY apt update
-      chroot $CRAFT_OVERLAY bash -c "DEBIAN_FRONTEND=noninteractive apt install sudo libapache2-mod-auth-gssapi python3-requests-kerberos keystone libapache2-mod-auth-mellon libapache2-mod-auth-openidc python3-ldappool --yes"
-      chroot $CRAFT_OVERLAY bash -c echo > etc/apache2/ports.conf
-      umount --recursive $CRAFT_OVERLAY/dev
-      umount $CRAFT_OVERLAY/sys
-      umount $CRAFT_OVERLAY/proc
-      umount $CRAFT_OVERLAY/etc/resolv.conf
+      - sudo
+      - keystone
+      - libapache2-mod-auth-gssapi
+      - libapache2-mod-auth-mellon
+      - libapache2-mod-auth-openidc
+      - python3-ldappool
+      - python3-requests-kerberos
+    override-prime: |
+      craftctl default
+      echo > $CRAFT_PRIME/etc/apache2/ports.conf

--- a/rocks/neutron-server/rockcraft.yaml
+++ b/rocks/neutron-server/rockcraft.yaml
@@ -9,12 +9,10 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
-# overlay packages from repositories
-# package-repositories:
-#   - type: apt
-#     cloud: antelope
-#     priority: always
+package-repositories:
+  - type: apt
+    cloud: antelope
+    priority: always
 
 services:
   neutron-server:
@@ -41,16 +39,10 @@ parts:
     after: [neutron-user]
     plugin: nil
     overlay-packages:
-      - software-properties-common
-    overlay-script: |
-      mount /etc/resolv.conf $CRAFT_OVERLAY/etc/resolv.conf --bind
-      mount proc $CRAFT_OVERLAY/proc -t proc
-      mount sysfs $CRAFT_OVERLAY/sys -t sysfs
-      mount /dev $CRAFT_OVERLAY/dev --rbind --make-private
-      chroot $CRAFT_OVERLAY add-apt-repository cloud-archive:antelope
-      chroot $CRAFT_OVERLAY apt update
-      chroot $CRAFT_OVERLAY bash -c "DEBIAN_FRONTEND=noninteractive apt install sudo neutron-server python3-ironic-neutron-agent python3-neutron-dynamic-routing python3-neutron-vpnaas python3-networking-sfc python3-oslo.vmware --yes"
-      umount --recursive $CRAFT_OVERLAY/dev
-      umount $CRAFT_OVERLAY/sys
-      umount $CRAFT_OVERLAY/proc
-      umount $CRAFT_OVERLAY/etc/resolv.conf
+      - sudo
+      - neutron-server
+      - python3-ironic-neutron-agent
+      - python3-neutron-dynamic-routing
+      - python3-neutron-vpnaas
+      - python3-networking-sfc
+      - python3-oslo.vmware

--- a/rocks/nova-api/rockcraft.yaml
+++ b/rocks/nova-api/rockcraft.yaml
@@ -9,12 +9,10 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
-# overlay packages from repositories
-# package-repositories:
-#   - type: apt
-#     cloud: antelope
-#     priority: always
+package-repositories:
+  - type: apt
+    cloud: antelope
+    priority: always
 
 services:
   wsgi-nova-api:
@@ -41,17 +39,10 @@ parts:
     after: [nova-user]
     plugin: nil
     overlay-packages:
-      - software-properties-common
-    overlay-script: |
-      mount /etc/resolv.conf $CRAFT_OVERLAY/etc/resolv.conf --bind
-      mount proc $CRAFT_OVERLAY/proc -t proc
-      mount sysfs $CRAFT_OVERLAY/sys -t sysfs
-      mount /dev $CRAFT_OVERLAY/dev --rbind --make-private
-      chroot $CRAFT_OVERLAY add-apt-repository cloud-archive:antelope
-      chroot $CRAFT_OVERLAY apt update
-      chroot $CRAFT_OVERLAY bash -c "DEBIAN_FRONTEND=noninteractive apt install sudo nova-api apache2 libapache2-mod-wsgi-py3 --yes"
-      chroot $CRAFT_OVERLAY bash -c echo > etc/apache2/ports.conf
-      umount --recursive $CRAFT_OVERLAY/dev
-      umount $CRAFT_OVERLAY/sys
-      umount $CRAFT_OVERLAY/proc
-      umount $CRAFT_OVERLAY/etc/resolv.conf
+      - sudo
+      - nova-api
+      - apache2
+      - libapache2-mod-wsgi-py3
+    override-prime: |
+      craftctl default
+      echo > $CRAFT_PRIME/etc/apache2/ports.conf

--- a/rocks/nova-conductor/rockcraft.yaml
+++ b/rocks/nova-conductor/rockcraft.yaml
@@ -9,12 +9,10 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
-# overlay packages from repositories
-# package-repositories:
-#   - type: apt
-#     cloud: antelope
-#     priority: always
+package-repositories:
+  - type: apt
+    cloud: antelope
+    priority: always
 
 services:
   nova-conductor:
@@ -41,16 +39,5 @@ parts:
     after: [nova-user]
     plugin: nil
     overlay-packages:
-      - software-properties-common
-    overlay-script: |
-      mount /etc/resolv.conf $CRAFT_OVERLAY/etc/resolv.conf --bind
-      mount proc $CRAFT_OVERLAY/proc -t proc
-      mount sysfs $CRAFT_OVERLAY/sys -t sysfs
-      mount /dev $CRAFT_OVERLAY/dev --rbind --make-private
-      chroot $CRAFT_OVERLAY add-apt-repository cloud-archive:antelope
-      chroot $CRAFT_OVERLAY apt update
-      chroot $CRAFT_OVERLAY bash -c "DEBIAN_FRONTEND=noninteractive apt install sudo nova-conductor --yes"
-      umount --recursive $CRAFT_OVERLAY/dev
-      umount $CRAFT_OVERLAY/sys
-      umount $CRAFT_OVERLAY/proc
-      umount $CRAFT_OVERLAY/etc/resolv.conf
+      - sudo
+      - nova-conductor

--- a/rocks/nova-scheduler/rockcraft.yaml
+++ b/rocks/nova-scheduler/rockcraft.yaml
@@ -9,12 +9,10 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
-# overlay packages from repositories
-# package-repositories:
-#   - type: apt
-#     cloud: antelope
-#     priority: always
+package-repositories:
+  - type: apt
+    cloud: antelope
+    priority: always
 
 services:
   nova-scheduler:
@@ -41,16 +39,5 @@ parts:
     after: [nova-user]
     plugin: nil
     overlay-packages:
-      - software-properties-common
-    overlay-script: |
-      mount /etc/resolv.conf $CRAFT_OVERLAY/etc/resolv.conf --bind
-      mount proc $CRAFT_OVERLAY/proc -t proc
-      mount sysfs $CRAFT_OVERLAY/sys -t sysfs
-      mount /dev $CRAFT_OVERLAY/dev --rbind --make-private
-      chroot $CRAFT_OVERLAY add-apt-repository cloud-archive:antelope
-      chroot $CRAFT_OVERLAY apt update
-      chroot $CRAFT_OVERLAY bash -c "DEBIAN_FRONTEND=noninteractive apt install sudo nova-scheduler --yes"
-      umount --recursive $CRAFT_OVERLAY/dev
-      umount $CRAFT_OVERLAY/sys
-      umount $CRAFT_OVERLAY/proc
-      umount $CRAFT_OVERLAY/etc/resolv.conf
+      - sudo
+      - nova-scheduler

--- a/rocks/ovn-nb-db-server/rockcraft.yaml
+++ b/rocks/ovn-nb-db-server/rockcraft.yaml
@@ -9,27 +9,17 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
-# overlay packages from repositories
-# package-repositories:
-#   - type: apt
-#     cloud: antelope
-#     priority: always
+package-repositories:
+  - type: apt
+    cloud: antelope
+    priority: always
 
 parts:
   ovn-nb-db-server:
     plugin: nil
     overlay-packages:
-      - software-properties-common
-    overlay-script: |
-      mount /etc/resolv.conf $CRAFT_OVERLAY/etc/resolv.conf --bind
-      mount proc $CRAFT_OVERLAY/proc -t proc
-      mount sysfs $CRAFT_OVERLAY/sys -t sysfs
-      mount /dev $CRAFT_OVERLAY/dev --rbind --make-private
-      chroot $CRAFT_OVERLAY add-apt-repository cloud-archive:antelope
-      chroot $CRAFT_OVERLAY apt update
-      chroot $CRAFT_OVERLAY bash -c "DEBIAN_FRONTEND=noninteractive apt install sudo ovn-central openvswitch-switch python3-openvswitch python3-netifaces --yes"
-      umount --recursive $CRAFT_OVERLAY/dev
-      umount $CRAFT_OVERLAY/sys
-      umount $CRAFT_OVERLAY/proc
-      umount $CRAFT_OVERLAY/etc/resolv.conf
+      - sudo
+      - ovn-central
+      - openvswitch-switch
+      - python3-openvswitch
+      - python3-netifaces

--- a/rocks/ovn-northd/rockcraft.yaml
+++ b/rocks/ovn-northd/rockcraft.yaml
@@ -9,27 +9,17 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
-# overlay packages from repositories
-# package-repositories:
-#   - type: apt
-#     cloud: antelope
-#     priority: always
+package-repositories:
+  - type: apt
+    cloud: antelope
+    priority: always
 
 parts:
   ovn-northd:
     plugin: nil
     overlay-packages:
-      - software-properties-common
-    overlay-script: |
-      mount /etc/resolv.conf $CRAFT_OVERLAY/etc/resolv.conf --bind
-      mount proc $CRAFT_OVERLAY/proc -t proc
-      mount sysfs $CRAFT_OVERLAY/sys -t sysfs
-      mount /dev $CRAFT_OVERLAY/dev --rbind --make-private
-      chroot $CRAFT_OVERLAY add-apt-repository cloud-archive:antelope
-      chroot $CRAFT_OVERLAY apt update
-      chroot $CRAFT_OVERLAY bash -c "DEBIAN_FRONTEND=noninteractive apt install sudo ovn-central openvswitch-switch python3-openvswitch python3-netifaces --yes"
-      umount --recursive $CRAFT_OVERLAY/dev
-      umount $CRAFT_OVERLAY/sys
-      umount $CRAFT_OVERLAY/proc
-      umount $CRAFT_OVERLAY/etc/resolv.conf
+      - sudo
+      - ovn-central
+      - openvswitch-switch
+      - python3-openvswitch
+      - python3-netifaces

--- a/rocks/ovn-sb-db-server/rockcraft.yaml
+++ b/rocks/ovn-sb-db-server/rockcraft.yaml
@@ -9,27 +9,17 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
-# overlay packages from repositories
-# package-repositories:
-#   - type: apt
-#     cloud: antelope
-#     priority: always
+package-repositories:
+  - type: apt
+    cloud: antelope
+    priority: always
 
 parts:
   ovn-sb-db-server:
     plugin: nil
     overlay-packages:
-      - software-properties-common
-    overlay-script: |
-      mount /etc/resolv.conf $CRAFT_OVERLAY/etc/resolv.conf --bind
-      mount proc $CRAFT_OVERLAY/proc -t proc
-      mount sysfs $CRAFT_OVERLAY/sys -t sysfs
-      mount /dev $CRAFT_OVERLAY/dev --rbind --make-private
-      chroot $CRAFT_OVERLAY add-apt-repository cloud-archive:antelope
-      chroot $CRAFT_OVERLAY apt update
-      chroot $CRAFT_OVERLAY bash -c "DEBIAN_FRONTEND=noninteractive apt install sudo ovn-central openvswitch-switch python3-openvswitch python3-netifaces --yes"
-      umount --recursive $CRAFT_OVERLAY/dev
-      umount $CRAFT_OVERLAY/sys
-      umount $CRAFT_OVERLAY/proc
-      umount $CRAFT_OVERLAY/etc/resolv.conf
+      - sudo
+      - ovn-central
+      - openvswitch-switch
+      - python3-openvswitch
+      - python3-netifaces

--- a/rocks/placement-api/rockcraft.yaml
+++ b/rocks/placement-api/rockcraft.yaml
@@ -9,12 +9,10 @@ base: ubuntu:22.04
 platforms:
   amd64:
 
-# Disabled until rockcraft supports 
-# overlay packages from repositories
-# package-repositories:
-#   - type: apt
-#     cloud: antelope
-#     priority: always
+package-repositories:
+  - type: apt
+    cloud: antelope
+    priority: always
 
 services:
   wsgi-placement-api:
@@ -41,17 +39,9 @@ parts:
     after: [placement-user]
     plugin: nil
     overlay-packages:
-      - software-properties-common
-    overlay-script: |
-      mount /etc/resolv.conf $CRAFT_OVERLAY/etc/resolv.conf --bind
-      mount proc $CRAFT_OVERLAY/proc -t proc
-      mount sysfs $CRAFT_OVERLAY/sys -t sysfs
-      mount /dev $CRAFT_OVERLAY/dev --rbind --make-private
-      chroot $CRAFT_OVERLAY add-apt-repository cloud-archive:antelope
-      chroot $CRAFT_OVERLAY apt update
-      chroot $CRAFT_OVERLAY bash -c "DEBIAN_FRONTEND=noninteractive apt install sudo placement-api python3-pymysql --yes"
-      chroot $CRAFT_OVERLAY bash -c echo > etc/apache2/ports.conf
-      umount --recursive $CRAFT_OVERLAY/dev
-      umount $CRAFT_OVERLAY/sys
-      umount $CRAFT_OVERLAY/proc
-      umount $CRAFT_OVERLAY/etc/resolv.conf
+      - sudo
+      - placement-api
+      - python3-pymysql
+    override-prime: |
+      craftctl default
+      echo > $CRAFT_PRIME/etc/apache2/ports.conf


### PR DESCRIPTION
Rockcraft has landed the feature necessary to allow packages being pulled into the overlay from a custom packages repository.