### PR TITLE
Add python3-netifaces to glance rock

### DIFF
--- a/rocks/glance-api/rockcraft.yaml
+++ b/rocks/glance-api/rockcraft.yaml
@@ -49,6 +49,7 @@ parts:
       - python3-boto3
       - python3-rados
       - python3-rbd
+      - python3-netifaces
       - apache2
       - libapache2-mod-wsgi-py3
     override-prime: |


### PR DESCRIPTION
Glance requires netifaces for ceph-ops-interface
and if package not found, glance charm tries to
download package at runtime. To avoid downloading
package at runtime, add netifaces to the rock.