### PR TITLE
rabbitmq: update to 3.12 release

### DIFF
--- a/rocks/rabbitmq/README.md
+++ b/rocks/rabbitmq/README.md
@@ -17,7 +17,7 @@ it will help ensure that all layers of the image are imported
 into docker (this is just the top layer).
 
 ```bash
-> skopeo --insecure-policy copy oci-archive:rabbitmq_3.9.13_amd64.rock docker-daemon:rabbitmq:3.9.13
+> skopeo --insecure-policy copy oci-archive:rabbitmq_3.12.1_amd64.rock docker-daemon:rabbitmq:3.12.1
 ```
 
 If you are interested in giving it a go in Microk8s, you can
@@ -25,8 +25,8 @@ export the image from your docker registry and then into the
 microk8s registry:
 
 ```bash
-> docker save rabbitmq:3.9.13 > ./rabbitmq.3.9.13.tar
-> microk8s ctr image import ./rabbitmq.3.9.13.tar
+> docker save rabbitmq:3.12.1 > ./rabbitmq.3.12.1.tar
+> microk8s ctr image import ./rabbitmq.3.12.1.tar
 # Try with sunbeam
-> juju attach-resource rabbitmq rabbitmq-image=rabbitmq:3.9.13
+> juju attach-resource rabbitmq rabbitmq-image=rabbitmq:3.12.1
 ```

--- a/rocks/rabbitmq/rockcraft.yaml
+++ b/rocks/rabbitmq/rockcraft.yaml
@@ -1,11 +1,16 @@
 name: rabbitmq
 summary: RabbitMQ
 description: AMQP based message broker.
-version: 3.9.13
+version: 3.12.1
 base: ubuntu:22.04
 license: Apache-2.0
 platforms:
   amd64:
+
+package-repositories:
+  - type: apt
+    ppa: ubuntu-cloud-archive/rabbitmq-3.12-updates
+    priority: always
 
 services:
   rabbitmq:


### PR DESCRIPTION
3.12 is currently only in >= Mantic so use the backport PPA owned by the Ubuntu Cloud Archive team until we get to 24.04.