### PR TITLE
Add plugin management capabilities to horizon

### DIFF
--- a/rocks/horizon/python/plugin_management.py
+++ b/rocks/horizon/python/plugin_management.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from pathlib import Path
+
+OS_DASHBOARD = Path("/usr/lib/python3/dist-packages/openstack_dashboard/")
+ENABLED = OS_DASHBOARD / "enabled"
+AVAILABLE = OS_DASHBOARD / "available"
+
+
+def _get_plugin_files(plugin: str) -> list[str]:
+    files = AVAILABLE / plugin
+    if not files.exists():
+        raise Exception(
+            f"No plugin files at {str(files)!r}, is {plugin!r} a supported plugin?"
+        )
+    return files.read_text().splitlines()
+
+
+def enable_plugin(plugin: str):
+    files = _get_plugin_files(plugin)
+    for file in files:
+        enabled = ENABLED / file
+        available = AVAILABLE / file
+        if enabled.exists():
+            continue
+        if not available.exists():
+            raise Exception(f"Plugin file {str(available)!r} does not exist")
+        enabled.symlink_to(available)
+        print(f"Enabled {file!r}")
+
+
+def disable_plugin(plugin: str):
+    files = _get_plugin_files(plugin)
+    for file in files:
+        enabled = ENABLED / file
+        if not enabled.exists():
+            continue
+        enabled.unlink()
+        print(f"Disabled {file!r}")
+
+
+COMMANDS = {
+    "enable": enable_plugin,
+    "disable": disable_plugin,
+}
+
+
+def main(cmd: str, plugins: list[str]):
+    command = COMMANDS.get(cmd)
+    if not command:
+        print(f"Unknown command {cmd!r}")
+        sys.exit(1)
+
+    for plugin in plugins:
+        command(plugin)
+
+
+def _usage():
+    print("Usage: plugin_management.py <command> <plugin>...")
+    print("Commands: " + ", ".join(COMMANDS.keys()))
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if "-h" in args or "--help" in args:
+        _usage()
+    else:
+        if len(args) < 2:
+            _usage()
+            sys.exit(1)
+        cmd, *plugins = args
+        main(cmd, plugins)

--- a/rocks/horizon/rockcraft.yaml
+++ b/rocks/horizon/rockcraft.yaml
@@ -45,3 +45,31 @@ parts:
     override-prime: |
       craftctl default
       echo > $CRAFT_PRIME/etc/apache2/ports.conf
+    
+  horizon-plugin:
+    plugin: dump
+    source: python/
+    organize:
+     plugin_management.py: usr/bin/plugin_management.py
+    override-prime: |
+      craftctl default
+      chmod 550 $CRAFT_PRIME/usr/bin/plugin_management.py
+
+  horizon-magnum-plugin:
+    after: [horizon]
+    plugin: nil
+    stage-packages:
+      - python3-magnum-ui
+    organize:
+      usr/lib/python3/dist-packages/openstack_dashboard/enabled/_1370_project_container_infra_panel_group.py: usr/lib/python3/dist-packages/openstack_dashboard/available/_1370_project_container_infra_panel_group.py
+      usr/lib/python3/dist-packages/openstack_dashboard/enabled/_1371_project_container_infra_clusters_panel.py: usr/lib/python3/dist-packages/openstack_dashboard/available/_1371_project_container_infra_clusters_panel.py
+      usr/lib/python3/dist-packages/openstack_dashboard/enabled/_1372_project_container_infra_cluster_templates_panel.py: usr/lib/python3/dist-packages/openstack_dashboard/available/_1372_project_container_infra_cluster_templates_panel.py
+      usr/lib/python3/dist-packages/openstack_dashboard/enabled/_2370_admin_container_infra_panel_group.py: usr/lib/python3/dist-packages/openstack_dashboard/available/_2370_admin_container_infra_panel_group.py
+      usr/lib/python3/dist-packages/openstack_dashboard/enabled/_2371_admin_container_infra_quotas_panel.py: usr/lib/python3/dist-packages/openstack_dashboard/available/_2371_admin_container_infra_quotas_panel.py
+    override-prime: |
+      craftctl default
+      echo "_1370_project_container_infra_panel_group.py
+      _1371_project_container_infra_clusters_panel.py
+      _1372_project_container_infra_cluster_templates_panel.py
+      _2370_admin_container_infra_panel_group.py
+      _2371_admin_container_infra_quotas_panel.py" > $CRAFT_PRIME/usr/lib/python3/dist-packages/openstack_dashboard/available/magnum


### PR DESCRIPTION
Horizon plugins are python files that must be placed in specific location.

This change is adding facilities to enable easy plugin management from the charm.

Adding the script `plugin_management.py`, with the following usage:
```
Usage: plugin_management.py <command> <plugin>...
Commands: enable, disable
```

Example:
```
/usr/bin/plugin_management.py enable magnum
Enabled '_1370_project_container_infra_panel_group.py'
Enabled '_1371_project_container_infra_clusters_panel.py'
Enabled '_1372_project_container_infra_cluster_templates_panel.py'
Enabled '_2370_admin_container_infra_panel_group.py'
Enabled '_2371_admin_container_infra_quotas_panel.py'
```

The plugin will lookup the file
`/usr/lib/python3/dist-packages/openstack_dashboard/available/<plugin name>`. If this file is missing, aborts.

This file should contain the name of the files necessary to enable the Horizon plugin. (only basenames)